### PR TITLE
add python bootstrapping for deb and rpm systems

### DIFF
--- a/tasks/apt_prepare.yml
+++ b/tasks/apt_prepare.yml
@@ -1,4 +1,18 @@
 ---
+- name: Check for python3
+  raw: test -e /usr/bin/python3
+  changed_when: false
+  failed_when: false
+  register: check_python
+
+- block:
+    - name: Install python3 from apt
+      become: yes
+      raw: apt update && apt install python3 -y
+    
+    - name: Test python3
+      raw: command -v python3
+  when: check_python.rc != 0
 
 - name: Ensure lsb-release, apt-transport-https and gpg packages are installed
   become: yes

--- a/tasks/apt_prepare.yml
+++ b/tasks/apt_prepare.yml
@@ -1,10 +1,4 @@
 ---
-- name: Check for python3
-  raw: test -e /usr/bin/python3
-  changed_when: false
-  failed_when: false
-  register: check_python
-
 - block:
     - name: Install python3 from apt
       become: yes
@@ -13,6 +7,9 @@
     - name: Test python3
       raw: command -v python3
   when: check_python.rc != 0
+
+- name: Gather facts
+  ansible.builtin.gather_facts:
 
 - name: Ensure lsb-release, apt-transport-https and gpg packages are installed
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- name: Check for python3
+  ansible.builtin.raw: test -e /usr/bin/python3
+  changed_when: false
+  failed_when: false
+  register: check_python
+
+- name: Check distro without ansible_facts
+  ansible.builtin.raw:
+    if [ -e /usr/bin/dnf ]; then echo "rpm"; else echo "apt"; fi
+  changed_when: false
+  failed_when: false
+  register: pkg_type
+
+- name: Import variables
+  ansible.builtin.include_tasks: "{{ pkg_type.stdout_lines[0] }}_prepare.yml"
 
 - name: Check for min. ansible version requirement
   assert:

--- a/tasks/rpm_prepare.yml
+++ b/tasks/rpm_prepare.yml
@@ -1,4 +1,18 @@
 ---
+- name: Check for python3
+  raw: test -e /usr/bin/python3
+  changed_when: false
+  failed_when: false
+  register: check_python
+
+- block:
+    - name: Install python3 from apt
+      become: yes
+      raw: yum update && dnf install python3 -y
+    
+    - name: Test python3
+      raw: command -v python3
+  when: check_python.rc != 0
 
 - name: Ensure EPEL repo is installed (yum)
   become: yes

--- a/tasks/rpm_prepare.yml
+++ b/tasks/rpm_prepare.yml
@@ -1,10 +1,4 @@
 ---
-- name: Check for python3
-  raw: test -e /usr/bin/python3
-  changed_when: false
-  failed_when: false
-  register: check_python
-
 - block:
     - name: Install python3 from dnf
       become: yes
@@ -13,6 +7,9 @@
     - name: Test python3
       raw: command -v python3
   when: check_python.rc != 0
+
+- name: Gather facts
+  ansible.builtin.gather_facts:
 
 - name: Ensure EPEL repo is installed (yum)
   become: yes

--- a/tasks/rpm_prepare.yml
+++ b/tasks/rpm_prepare.yml
@@ -6,7 +6,7 @@
   register: check_python
 
 - block:
-    - name: Install python3 from apt
+    - name: Install python3 from dnf
       become: yes
       raw: yum update && dnf install python3 -y
     


### PR DESCRIPTION
It is possible that the newly deployed server don't have python3 on board yet.
This can be due to, for instance, the lack of configurable "user data" or a generic bootstrapping scripts capability on the cloud provider.
This feature checks for the python3 command and, where applicable, installs it from the official apt and rpm repos.