### PR TITLE
feature: disable root login at the end of 1st run

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -77,3 +77,10 @@
     state: reloaded
   with_items: "{{ tor_instances_tmp.results }}"
   when: ansible_system == 'OpenBSD'
+
+- name: restart sshd
+  become: yes
+  systemd:
+    name: sshd
+    state: restarted
+  when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -192,7 +192,7 @@
   tags:
     - always
 
-- name: Disable Root Login (first run only)
+- name: Disable Root Login if needed
   become: yes
   lineinfile:
     dest: /etc/ssh/sshd_config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -176,3 +176,19 @@
   when: tor_gen_ciiss_proof_files
   tags:
     - always
+
+- name: Disable Root Login (first run only)
+  become: yes
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: '^PermitRootLogin'
+    line: "PermitRootLogin no"
+    state: present
+    backup: yes
+  notify:
+    - restart sshd
+  tags:
+   - debian
+   - centos
+   - fedora
+   - install

--- a/tasks/user_creation.yml
+++ b/tasks/user_creation.yml
@@ -9,7 +9,7 @@
   ansible.posix.authorized_key:
     user: "{{ admin_user }}"
     state: present
-    key: "{{ lookup('file', '~/.ssh/id_savetor.pub') }}"
+    key: "{{ lookup('file', '{{ ansible_ssh_key_file }}.pub') }}"
 
 - name: Enable NOPASSWD for admin user
   ansible.builtin.lineinfile:


### PR DESCRIPTION
disables the possibility to login via ssh as `root` after the 1st bootstrapping run